### PR TITLE
Added rules from PHP-cs-fixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/*
 composer.lock
 .idea/*
 .phpunit.result.cache
+/.php_cs.cache

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ vendor/*
 composer.lock
 .idea/*
 .phpunit.result.cache
-/.php_cs.cache
+.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,13 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__.'/src')
+    ->in(__DIR__.'/tests')
+;
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@Symfony' => true,
+    ])
+    ->setFinder($finder)
+;

--- a/.php_cs
+++ b/.php_cs
@@ -7,7 +7,7 @@ $finder = PhpCsFixer\Finder::create()
 
 return PhpCsFixer\Config::create()
     ->setRules([
-        '@psr2' => true,
+        '@PSR2' => true,
         '@Symfony' => true,
     ])
     ->setFinder($finder)

--- a/.php_cs
+++ b/.php_cs
@@ -7,6 +7,7 @@ $finder = PhpCsFixer\Finder::create()
 
 return PhpCsFixer\Config::create()
     ->setRules([
+        '@psr2' => true,
         '@Symfony' => true,
     ])
     ->setFinder($finder)


### PR DESCRIPTION
I added some default config. Please remove or modify rules how much you want.  See a full list of config options here: https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage (or here for a nice UI: https://mlocati.github.io/php-cs-fixer-configurator)

To actually fix things, just run: 

```bash
# install
curl -L https://cs.symfony.com/download/php-cs-fixer-v2.phar -o php-cs-fixer
sudo chmod a+x php-cs-fixer

# Fix CS
php-cs-fixer fix
```