### PR TITLE
Require browser-kit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "php": "^7.2",
     "symfony/framework-bundle": "^4.4 || ^5.0",
     "symfony/http-foundation": "^4.4.7 || ^5.0.7",
+    "symfony/browser-kit": "^4.4.7 || ^5.0.7",
     "ext-json": "*"
   },
   "autoload": {


### PR DESCRIPTION
I was wrong. We do need browser kit. 

The HttpKernel nor Framework bundle require it.